### PR TITLE
docs: 技術スタック.md を追加

### DIFF
--- a/docs/技術スタック.md
+++ b/docs/技術スタック.md
@@ -1,0 +1,125 @@
+# 技術スタック
+
+RecipeManager で採用する技術と、開発環境におけるバージョンを記載する。
+要件定義書「3. 技術構成」の補足ドキュメントであり、バージョン更新時は本ファイルを更新する。
+
+最終更新: 2026-05-03
+
+---
+
+## 1. 言語・ランタイム
+
+| カテゴリ | 技術 | バージョン | バージョン管理ツール |
+| --- | --- | --- | --- |
+| フロントエンド言語 | TypeScript | 5.x (最新) | npm (Next.js 同梱) |
+| フロントエンドランタイム | Node.js | **22.x (LTS)** | **Volta** |
+| バックエンド言語 | Ruby | **3.4.9** | **rbenv** |
+
+### Node.js (Volta)
+- 本プロジェクトのフロントは Node.js v22 LTS を使用する。
+- バージョン管理は [Volta](https://volta.sh/) を採用。プロジェクト直下に配置する `package.json` の `volta` フィールド、または `.node-version` で固定する。
+- Homebrew 版 Node も共存可だが、`PATH` 上は Volta 管理の Node が優先される想定。
+
+### Ruby (rbenv)
+- バージョン管理は [rbenv](https://github.com/rbenv/rbenv) を採用。
+- プロジェクト直下に `.ruby-version`(内容: `3.4.9`)を配置し、ディレクトリ移動時に自動で切り替わるようにする。
+- macOS システム標準の Ruby (2.6.x) は触らない。
+
+---
+
+## 2. フレームワーク・主要ライブラリ
+
+| カテゴリ | 技術 | バージョン |
+| --- | --- | --- |
+| フロントエンドフレームワーク | **Next.js (Pages Router)** | 15.x (最新安定版) |
+| バックエンドフレームワーク | **Ruby on Rails (API mode)** | **8.1.3** |
+| パッケージマネージャ (Ruby) | Bundler | 4.x |
+| パッケージマネージャ (Node) | npm | 11.x |
+
+---
+
+## 3. データベース
+
+| 技術 | バージョン | 備考 |
+| --- | --- | --- |
+| **MySQL** | 8.0.x | ローカル開発は Homebrew 版 or Docker |
+
+---
+
+## 4. インフラ
+
+- **AWS** 上にデプロイ予定(TaskManagement と同等の構成を踏襲)
+- 詳細構成は別途インフラ設計書にて定義
+
+---
+
+## 5. ポート運用
+
+CLAUDE.md「ポート運用ルール」に準拠。**別ポートでの代替起動は禁止**。
+
+| サービス | ポート |
+| --- | --- |
+| フロントエンド (Next.js dev server) | `3000` |
+| バックエンド (Rails API) | `3001` |
+| MySQL | `3306` |
+
+ポート競合時は占有プロセスを停止してから本来のポートで起動し直す。
+
+---
+
+## 6. 開発環境セットアップ手順
+
+### 6.1 Node.js (Volta)
+
+```bash
+# Volta インストール
+curl https://get.volta.sh | bash
+
+# シェル再起動後
+volta install node@22
+volta install npm@latest
+
+node -v   # v22.x
+npm -v    # 11.x
+```
+
+### 6.2 Ruby (rbenv)
+
+```bash
+# rbenv インストール
+brew install rbenv ruby-build
+
+# シェル設定 (~/.zshrc 等) に追記
+eval "$(rbenv init - bash)"   # zsh の場合は - zsh
+
+# Ruby 3.4.9 インストール
+rbenv install 3.4.9
+rbenv global 3.4.9
+
+ruby -v   # ruby 3.4.9
+```
+
+### 6.3 Rails / Bundler
+
+```bash
+gem update --system
+gem install bundler rails
+
+bundle -v  # 4.x
+rails -v   # Rails 8.1.x
+```
+
+### 6.4 MySQL
+
+```bash
+brew install mysql
+brew services start mysql
+mysql --version  # 8.0.x
+```
+
+---
+
+## 7. バージョン更新時のルール
+
+- メジャーバージョン更新 (例: Ruby 3.4 → 3.5、Rails 8 → 9) は Issue を起票し、影響範囲を確認のうえ実施する。
+- 更新後は本ファイルおよび `.ruby-version` / `package.json` の `volta` フィールド等を必ず更新する。


### PR DESCRIPTION
## Summary
- `docs/技術スタック.md` を新規追加
- 各言語・フレームワークのバージョンを明記:
  - Node.js v22 LTS (Volta 管理)
  - Ruby 3.4.9 (rbenv 管理) / Rails 8.1.3 / Bundler 4.x
  - MySQL 8.0.x
- バージョン管理ツール (Volta / rbenv) のセットアップ手順を記載
- CLAUDE.md のポート運用ルールを再掲し整合性を担保

## Test plan
- [x] ドキュメントの内容に齟齬がないか目視確認
- [x] 要件定義書「3. 技術構成」と矛盾がないこと

Closes #3