### PR TITLE
docs: 開発計画書を追加 (#7)

### DIFF
--- a/docs/開発計画書.md
+++ b/docs/開発計画書.md
@@ -1,0 +1,148 @@
+# RecipeManager 開発計画書
+
+最終更新: 2026-05-03
+
+---
+
+## 概要
+
+docs/ に要件定義書・機能仕様書・画面設計書・ER図・技術スタックが揃い、prototype/ に静的 HTML/CSS/JS の UI モックがある状態から開発を開始する。
+
+**技術構成**: Next.js 15 (Pages Router, TypeScript) + Rails 8.1.3 (API mode) + MySQL 8.0
+
+**スコープ**: レシピ CRUD 5 機能（認証なし、単一テーブル `recipes`）
+
+---
+
+## ディレクトリ構成（モノレポ）
+
+```
+RecipeManager/
+├── frontend/   # Next.js 15 (Pages Router) + TypeScript
+├── backend/    # Rails 8.1.3 API
+├── docs/
+└── prototype/
+```
+
+---
+
+## 品質チェックのルール
+
+**各フェーズの PR 作成前に `/quality-review` skill を実行する。** 指摘があれば修正してから PR を作成する。最終フェーズ完了後にも全体の品質チェックを行う。
+
+---
+
+## 開発フェーズ
+
+各フェーズ = 1 Issue + 1 ブランチ + **品質チェック** + 1 PR。
+
+| フェーズ | 内容 | ブランチ種別 | 状態 |
+|---|---|---|---|
+| Phase 1 | バックエンド初期セットアップ | `chore` | ✅ 完了 (PR #6) |
+| Phase 2 | Recipe モデル + マイグレーション | `feat` | 未着手 |
+| Phase 3 | Recipes API 実装 | `feat` | 未着手 |
+| Phase 4 | フロントエンド初期セットアップ | `chore` | 未着手 |
+| Phase 5 | 画面実装（4 画面） | `feat` | 未着手 |
+| Phase 6 | 動作確認・README | `docs` | 未着手 |
+
+---
+
+### Phase 1: バックエンド初期セットアップ ✅
+
+- `rails new backend --api -d mysql --skip-test` で生成
+- `.ruby-version` (3.4.9) を `backend/` に配置
+- `config/database.yml` を MySQL 接続に（DB: `recipemanager_development` / `_test`）
+- CORS: `rack-cors` で `http://localhost:3000` を許可
+- DB 認証情報を環境変数（`DB_USERNAME` / `DB_PASSWORD`）経由に変更
+- `.env.example` を追加
+- `bin/rails db:create` 成功確認
+
+---
+
+### Phase 2: Recipe モデル + マイグレーション
+
+- `recipes` テーブル作成
+  - `id`, `title` (string, null:false), `category` (string)
+  - `ingredients` (json), `steps` (json)
+  - `servings` (int), `cooking_time` (int), `memo` (text)
+  - `created_at`, `updated_at`
+- `Recipe` モデルにバリデーション追加
+  - `title`: 必須・100 字以内
+  - `category`: 和食 / 洋食 / 中華 / その他 の inclusion
+- `bin/rails db:migrate` 成功確認
+
+---
+
+### Phase 3: Recipes API 実装
+
+- `Api::RecipesController` に index / show / create / update / destroy
+- ルーティング: `namespace :api { resources :recipes }`
+- index のクエリパラメータ
+  - `keyword`: title LIKE 検索
+  - `category`: 完全一致絞り込み
+  - `sort`: `created_desc` / `name_asc`
+- JSON レスポンス統一フォーマット（as_json または jbuilder）
+- エラー時 422 / 404 を JSON で返す
+- `curl` で 5 エンドポイント動作確認
+
+---
+
+### Phase 4: フロントエンド初期セットアップ
+
+- `npx create-next-app@latest frontend --ts --no-app --eslint`（Pages Router）
+- Volta フィールドを `frontend/package.json` に追加（node 22, npm 11）
+- API クライアント `lib/api.ts`（fetch ラッパ、`NEXT_PUBLIC_API_BASE=http://localhost:3001/api`）
+- 共通レイアウト / ヘッダー / グローバル CSS を `prototype/styles.css` をベースに移植
+
+---
+
+### Phase 5: 画面実装
+
+`prototype/` の HTML/CSS を React コンポーネント化。
+
+| 画面 ID | ファイル | 概要 |
+|---|---|---|
+| S-01 | `pages/recipes/index.tsx` | 一覧 + 検索 / 絞り込み / 並べ替え |
+| S-02 | `pages/recipes/[id].tsx` | 詳細、編集 / 削除ボタン |
+| S-03 | `pages/recipes/new.tsx` | 登録フォーム（材料 / 手順の動的行追加） |
+| S-04 | `pages/recipes/[id]/edit.tsx` | 編集フォーム |
+
+- `pages/index.tsx` は `/recipes` へリダイレクト
+- 削除は確認ダイアログ後に DELETE → 一覧へ遷移
+
+---
+
+### Phase 6: 動作確認・README
+
+- ルートに `README.md`（起動手順: MySQL → backend → frontend、ポート規定）
+- 5 機能を手動で一巡（一覧 / 検索 / 詳細 / 登録 / 編集 / 削除）
+
+---
+
+## 再利用する既存資産
+
+| ファイル | 用途 |
+|---|---|
+| `prototype/styles.css` | カラー（#d97706 等）・カードスタイルを流用 |
+| `prototype/form.js` | 材料 / 手順の動的行追加ロジックを `useState` 化の参考に |
+| `prototype/app.js` | 検索 / フィルター / 並べ替えの UI 挙動の参考に |
+
+---
+
+## 最終検証方法
+
+1. MySQL 起動
+2. `cd backend && bin/rails db:migrate && bin/rails s -p 3001`
+3. 別タブで `cd frontend && npm run dev`（→ port 3000）
+4. ブラウザで http://localhost:3000/recipes を開く
+5. 登録 → 一覧 → 検索 / 絞り込み / 並べ替え → 詳細 → 編集 → 削除 を一巡
+6. `curl` で API 単体確認（GET / POST / PUT / DELETE `/api/recipes`）
+
+---
+
+## 留意事項
+
+- 各 Phase 完了ごとに `gh pr create` → squash マージ → 次 Phase へ
+- `main` 直 push 禁止、PR 本文に `Closes #N`
+- ポート競合時は占有プロセスを停止して規定ポートで起動し直す（別ポート禁止）
+- 認証・画像アップロード・タグ等は仕様外のため実装しない


### PR DESCRIPTION
## 概要
開発プランをプロジェクト内のドキュメントとして `docs/開発計画書.md` に保存しました。

## 内容
- 6フェーズの開発計画（Phase 1〜6）
- 各フェーズの作業内容・完了条件
- Phase 1 の完了状態を反映
- 再利用する既存資産（prototype/）の整理
- 最終検証方法・留意事項

Closes #7