### PR TITLE
feat: Phase 2 Recipe モデル + マイグレーション

### DIFF
--- a/backend/app/models/recipe.rb
+++ b/backend/app/models/recipe.rb
@@ -1,0 +1,6 @@
+class Recipe < ApplicationRecord
+  CATEGORIES = %w[和食 洋食 中華 その他].freeze
+
+  validates :title, presence: true, length: { maximum: 100 }
+  validates :category, inclusion: { in: CATEGORIES }, length: { maximum: 50 }, allow_blank: true
+end

--- a/backend/db/migrate/20260503121617_create_recipes.rb
+++ b/backend/db/migrate/20260503121617_create_recipes.rb
@@ -1,0 +1,15 @@
+class CreateRecipes < ActiveRecord::Migration[8.1]
+  def change
+    create_table :recipes do |t|
+      t.string :title, null: false
+      t.string :category
+      t.json :ingredients
+      t.json :steps
+      t.integer :servings
+      t.integer :cooking_time
+      t.text :memo
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -1,0 +1,25 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.1].define(version: 2026_05_03_121617) do
+  create_table "recipes", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "category"
+    t.integer "cooking_time"
+    t.datetime "created_at", null: false
+    t.json "ingredients"
+    t.text "memo"
+    t.integer "servings"
+    t.json "steps"
+    t.string "title", null: false
+    t.datetime "updated_at", null: false
+  end
+end


### PR DESCRIPTION
## 概要
recipes テーブルのマイグレーションと Recipe モデル（バリデーション付き）を追加する。

## 変更内容
- `db/migrate/..._create_recipes.rb`: recipes テーブル作成
  - `title` (string, NOT NULL), `category` (string), `ingredients` (json), `steps` (json)
  - `servings` (int), `cooking_time` (int), `memo` (text), timestamps
- `app/models/recipe.rb`: バリデーション追加
  - `title`: 必須・最大100文字
  - `category`: 和食/洋食/中華/その他 の inclusion・最大50文字

## 動作確認
- `bin/rails db:migrate` 成功確認済み

## 品質チェック
- `/quality-review` 実施済み
  - 機能仕様書の `category` 最大50文字バリデーション漏れを検出 → 修正済み

Closes #9