### PR TITLE
chore: Docker Compose で MySQL + Rails 開発環境を構築

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+DB_USERNAME=root
+DB_PASSWORD=

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,4 @@
+DB_USERNAME=root
+DB_PASSWORD=
+# Docker Compose 使用時: DB_HOST=db / ローカル MySQL 使用時: DB_HOST=127.0.0.1
+DB_HOST=db

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -7,8 +7,9 @@
 # Ignore bundler config.
 /.bundle
 
-# Ignore all environment files.
+# Ignore all environment files (except .example).
 /.env*
+!/.env.example
 
 # Ignore all logfiles and tempfiles.
 /log/*

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -1,0 +1,20 @@
+ARG RUBY_VERSION=3.4.9
+FROM docker.io/library/ruby:$RUBY_VERSION-slim
+
+WORKDIR /rails
+
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y \
+      build-essential \
+      default-libmysqlclient-dev \
+      git \
+      libyaml-dev \
+      pkg-config && \
+    rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+
+COPY . .
+
+EXPOSE 3001

--- a/backend/config/database.yml
+++ b/backend/config/database.yml
@@ -15,7 +15,8 @@ default: &default
   max_connections: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: <%= ENV.fetch("DB_USERNAME") { "root" } %>
   password: <%= ENV["DB_PASSWORD"] %>
-  socket: /tmp/mysql.sock
+  host: <%= ENV.fetch("DB_HOST") { "127.0.0.1" } %>
+  port: 3306
 
 development:
   <<: *default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+services:
+  db:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
+      MYSQL_DATABASE: recipemanager_development
+    ports:
+      - "3306:3306"
+    volumes:
+      - db_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${DB_PASSWORD}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile.dev
+    command: bin/rails server -p 3001 -b 0.0.0.0
+    environment:
+      DB_USERNAME: ${DB_USERNAME}
+      DB_PASSWORD: ${DB_PASSWORD}
+      DB_HOST: db
+      RAILS_ENV: development
+    ports:
+      - "3001:3001"
+    volumes:
+      - ./backend:/rails
+    depends_on:
+      db:
+        condition: service_healthy
+
+volumes:
+  db_data:


### PR DESCRIPTION
## 概要
docker-compose.yml を追加し、`docker compose up` だけで MySQL + Rails が起動する開発環境を構築する。

## 変更内容
- `docker-compose.yml`: db（MySQL 8.0）と backend（Rails 3001）のサービス定義
- `backend/Dockerfile.dev`: 開発用イメージ（プロダクション用 Dockerfile とは別）
- `backend/config/database.yml`: socket 接続 → host/port 接続に変更（`DB_HOST` 環境変数で切り替え可能）
- `.env.example`（ルート）: docker-compose 用の環境変数サンプル
- `backend/.env.example`: Rails 用の環境変数サンプル
- `backend/.gitignore`: `.env.example` を追跡対象に戻す

## 動作確認
- `docker compose build` 成功
- `docker compose run --rm backend bin/rails db:migrate:status` → `up 20260503121617 Create recipes` 確認済み

## 品質チェック
- `/quality-review` 実施済み・指摘事項なし

Closes #11