### PR TITLE
docs: 開発計画書に Phase 6 UI 改善を追加し Phase 番号を繰り下げ

### DIFF
--- a/docs/開発計画書.md
+++ b/docs/開発計画書.md
@@ -1,6 +1,6 @@
 # RecipeManager 開発計画書
 
-最終更新: 2026-05-03
+最終更新: 2026-05-04
 
 ---
 
@@ -39,11 +39,12 @@ RecipeManager/
 | フェーズ | 内容 | ブランチ種別 | 状態 |
 |---|---|---|---|
 | Phase 1 | バックエンド初期セットアップ | `chore` | ✅ 完了 (PR #6) |
-| Phase 2 | Recipe モデル + マイグレーション | `feat` | 未着手 |
-| Phase 3 | Recipes API 実装 | `feat` | 未着手 |
-| Phase 4 | フロントエンド初期セットアップ | `chore` | 未着手 |
-| Phase 5 | 画面実装（4 画面） | `feat` | 未着手 |
-| Phase 6 | 動作確認・README | `docs` | 未着手 |
+| Phase 2 | Recipe モデル + マイグレーション | `feat` | ✅ 完了 (PR #10) |
+| Phase 3 | Recipes API 実装 | `feat` | ✅ 完了 (PR #14) |
+| Phase 4 | フロントエンド初期セットアップ | `chore` | ✅ 完了 (PR #16) |
+| Phase 5 | 画面実装（4 画面） | `feat` | ✅ 完了 (PR #18) |
+| Phase 6 | UI 改善（提案 1〜9） | `feat` | 未着手 |
+| Phase 7 | 動作確認・README | `docs` | 未着手 |
 
 ---
 
@@ -112,10 +113,43 @@ RecipeManager/
 
 ---
 
-### Phase 6: 動作確認・README
+### Phase 6: UI 改善（提案 1〜9 全対応）
 
-- ルートに `README.md`（起動手順: MySQL → backend → frontend、ポート規定）
+Phase 5 完了時点で洗い出した [docs/UI改善提案.md](./UI改善提案.md) の 9 件を実装する。最終確認・README より前に UX を磨いておくことで、Phase 7 のスクリーンショット・動作手順が完成形になる。
+
+#### 高インパクト
+1. **フォームバリデーションの可視化**（`frontend/components/RecipeForm.tsx`）
+   - エラー対象 input に `.has-error` クラスで赤枠
+   - onChange でエラー解除
+   - submit 時、最初のエラーフィールドへ `scrollIntoView`
+2. **一覧カードのグリッド化と情報密度向上**（`frontend/pages/recipes/index.tsx`）
+   - CSS Grid `repeat(auto-fill, minmax(280px, 1fr))`
+   - 「🍴人数 / ⏱時間 / 🥕材料数」をアイコン+数値で表示、更新日も小さく追加
+3. **検索のデバウンス（300ms）** — `keyword` 用 `useEffect` に `setTimeout` + cleanup
+
+#### 中インパクト
+4. **削除確認モーダルの色反転**（`frontend/pages/recipes/[id].tsx`）
+   - OK を `btn-danger`（赤）に、キャンセルを強調、文言「削除する」
+   - `btn-danger` クラスがなければ `frontend/styles/globals.css` に追加
+5. **戻る導線の統一** — 詳細/編集/新規画面のヘッダー直下にパンくず or 戻る矢印を共通配置（`components/Layout.tsx` か新規 `components/Breadcrumb.tsx`）
+6. **動的行追加の追従型 UX**（`RecipeForm.tsx`）
+   - 最終行で Enter → 次行追加
+   - 最終行に値が入ったら自動で空行 1 行追加
+
+#### 低インパクト
+7. **数値入力欄の幅最適化** — `cooking_time` / `servings` を `flex: 0 0 120px`、`category` を可変
+8. **詳細画面の見出し** — `【材料】`/`【手順】` を `<h3>` の「材料」「作り方」へフラット化
+9. **ヘッダー右側に常設「+ 新規登録」ボタン**（`frontend/components/Header.tsx`）
+
+PR 作成前に `/quality-review` を実行し、ブラウザで全画面の手動確認を行う。
+
+---
+
+### Phase 7: 動作確認・README
+
+- ルートに `README.md`（起動手順: MySQL → backend → frontend、ポート規定 3000/3001/3306）
 - 5 機能を手動で一巡（一覧 / 検索 / 詳細 / 登録 / 編集 / 削除）
+- Phase 6 改善後の UI で再確認
 
 ---
 


### PR DESCRIPTION
## Summary
- Phase 5 完了時点で挙げた `docs/UI改善提案.md` の 9 件を実装する **新 Phase 6「UI 改善」** を追加
- 旧 Phase 6「動作確認・README」を **Phase 7** に繰り下げ
- 完了済み Phase 2〜5 のステータスを ✅ に更新、最終更新日を 2026-05-04 に

## Test plan
- [ ] `docs/開発計画書.md` のフェーズ表が 7 行になっていることを確認
- [ ] 新 Phase 6 セクションに UI 改善提案 1〜9 がすべて記載されていることを確認
- [ ] `docs/UI改善提案.md` への参照リンクが機能することを確認

ドキュメントのみ・コード変更なしのため `/quality-review` はスキップ。

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)