### PR TITLE
feat: Phase 6 UI 改善（提案 1〜9 全対応）

### DIFF
--- a/frontend/components/Breadcrumb.tsx
+++ b/frontend/components/Breadcrumb.tsx
@@ -1,0 +1,14 @@
+import Link from "next/link";
+
+type Props = {
+  href: string;
+  label?: string;
+};
+
+export default function Breadcrumb({ href, label = "← 一覧へ戻る" }: Props) {
+  return (
+    <Link href={href} className="back-link">
+      {label}
+    </Link>
+  );
+}

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -1,11 +1,21 @@
 import Link from "next/link";
+import { useRouter } from "next/router";
 
 export default function Header() {
+  const router = useRouter();
+  const showNewButton = router.pathname !== "/recipes/new";
   return (
     <header className="header">
-      <h1>
-        <Link href="/recipes">RecipeManager</Link>
-      </h1>
+      <div className="header-inner">
+        <h1>
+          <Link href="/recipes">RecipeManager</Link>
+        </h1>
+        {showNewButton && (
+          <Link href="/recipes/new" className="btn btn-primary">
+            + 新規登録
+          </Link>
+        )}
+      </div>
     </header>
   );
 }

--- a/frontend/components/RecipeForm.tsx
+++ b/frontend/components/RecipeForm.tsx
@@ -1,4 +1,4 @@
-import { useState, type FormEvent } from "react";
+import { useRef, useState, type FormEvent, type KeyboardEvent } from "react";
 import type { Recipe, RecipeInput } from "@/lib/api";
 import { CATEGORIES, COOKING_TIME_OPTIONS, SERVINGS_OPTIONS, UNIT_OPTIONS, toHalfWidthDigits } from "@/lib/constants";
 
@@ -13,20 +13,24 @@ type Props = {
   onCancel: () => void;
 };
 
+type Errors = { title?: string; ingredients?: string; steps?: string };
+
 function initialIngredients(initial?: Recipe): IngredientRow[] {
   if (initial?.ingredients?.length) {
-    return initial.ingredients.map((i) => ({
+    const rows = initial.ingredients.map((i) => ({
       name: i.name ?? "",
       amount: i.amount ?? "",
       unit: i.unit ?? "",
     }));
+    return [...rows, { name: "", amount: "", unit: "" }];
   }
   return [{ name: "", amount: "", unit: "" }];
 }
 
 function initialSteps(initial?: Recipe): StepRow[] {
   if (initial?.steps?.length) {
-    return initial.steps.map((s) => ({ description: s.description ?? "" }));
+    const rows = initial.steps.map((s) => ({ description: s.description ?? "" }));
+    return [...rows, { description: "" }];
   }
   return [{ description: "" }];
 }
@@ -39,13 +43,55 @@ export default function RecipeForm({ mode, initial, submitting, onSubmit, onCanc
   const [memo, setMemo] = useState(initial?.memo ?? "");
   const [ingredients, setIngredients] = useState<IngredientRow[]>(() => initialIngredients(initial));
   const [steps, setSteps] = useState<StepRow[]>(() => initialSteps(initial));
-  const [errors, setErrors] = useState<{ title?: string; ingredients?: string; steps?: string }>({});
+  const [errors, setErrors] = useState<Errors>({});
+
+  const titleRef = useRef<HTMLInputElement>(null);
+  const ingredientsRef = useRef<HTMLDivElement>(null);
+  const stepsRef = useRef<HTMLDivElement>(null);
+
+  function clearError(key: keyof Errors) {
+    setErrors((e) => (e[key] ? { ...e, [key]: undefined } : e));
+  }
 
   function updateIngredient(idx: number, patch: Partial<IngredientRow>) {
-    setIngredients((rows) => rows.map((r, i) => (i === idx ? { ...r, ...patch } : r)));
+    setIngredients((rows) => {
+      const next = rows.map((r, i) => (i === idx ? { ...r, ...patch } : r));
+      // 追従型 UX: 最終行に値が入ったら自動で空行を追加
+      const last = next[next.length - 1];
+      if (idx === next.length - 1 && last.name.trim() !== "") {
+        return [...next, { name: "", amount: "", unit: "" }];
+      }
+      return next;
+    });
+    clearError("ingredients");
   }
   function updateStep(idx: number, description: string) {
-    setSteps((rows) => rows.map((r, i) => (i === idx ? { description } : r)));
+    setSteps((rows) => {
+      const next = rows.map((r, i) => (i === idx ? { description } : r));
+      const last = next[next.length - 1];
+      if (idx === next.length - 1 && last.description.trim() !== "") {
+        return [...next, { description: "" }];
+      }
+      return next;
+    });
+    clearError("steps");
+  }
+
+  function handleIngredientKeyDown(e: KeyboardEvent<HTMLInputElement>, idx: number) {
+    if (e.key === "Enter" && idx === ingredients.length - 1) {
+      e.preventDefault();
+      if (ingredients[idx].name.trim() !== "") {
+        setIngredients((rows) => [...rows, { name: "", amount: "", unit: "" }]);
+      }
+    }
+  }
+  function handleStepKeyDown(e: KeyboardEvent<HTMLInputElement>, idx: number) {
+    if (e.key === "Enter" && idx === steps.length - 1) {
+      e.preventDefault();
+      if (steps[idx].description.trim() !== "") {
+        setSteps((rows) => [...rows, { description: "" }]);
+      }
+    }
   }
 
   function handleSubmit(e: FormEvent) {
@@ -57,12 +103,21 @@ export default function RecipeForm({ mode, initial, submitting, onSubmit, onCanc
       .map((s, idx) => ({ order: idx + 1, description: s.description.trim() }))
       .filter((s) => s.description);
 
-    const newErrors: typeof errors = {};
+    const newErrors: Errors = {};
     if (!title.trim()) newErrors.title = "レシピ名を入力してください";
     if (cleanIngs.length === 0) newErrors.ingredients = "材料を 1 件以上入力してください";
     if (cleanSteps.length === 0) newErrors.steps = "手順を 1 件以上入力してください";
     setErrors(newErrors);
-    if (Object.keys(newErrors).length > 0) return;
+    if (Object.keys(newErrors).length > 0) {
+      const target = newErrors.title
+        ? titleRef.current
+        : newErrors.ingredients
+          ? ingredientsRef.current
+          : stepsRef.current;
+      target?.scrollIntoView({ behavior: "smooth", block: "center" });
+      target?.focus?.();
+      return;
+    }
 
     onSubmit({
       title: title.trim(),
@@ -80,14 +135,18 @@ export default function RecipeForm({ mode, initial, submitting, onSubmit, onCanc
       <h2>{mode === "new" ? "新規レシピ登録" : "レシピ編集"}</h2>
       <hr className="divider" />
 
-      <div className="form-group">
+      <div className={`form-group${errors.title ? " has-error" : ""}`}>
         <label htmlFor="title" className="required">レシピ名</label>
         <input
+          ref={titleRef}
           id="title"
           type="text"
           maxLength={100}
           value={title}
-          onChange={(e) => setTitle(e.target.value)}
+          onChange={(e) => {
+            setTitle(e.target.value);
+            clearError("title");
+          }}
         />
         {errors.title && <div className="error-msg">{errors.title}</div>}
       </div>
@@ -102,7 +161,7 @@ export default function RecipeForm({ mode, initial, submitting, onSubmit, onCanc
             ))}
           </select>
         </div>
-        <div className="form-group">
+        <div className="form-group numeric">
           <label htmlFor="cooking_time">調理時間 (分)</label>
           <input
             id="cooking_time"
@@ -117,7 +176,7 @@ export default function RecipeForm({ mode, initial, submitting, onSubmit, onCanc
             {COOKING_TIME_OPTIONS.map((v) => <option key={v} value={v} />)}
           </datalist>
         </div>
-        <div className="form-group">
+        <div className="form-group numeric">
           <label htmlFor="servings">何人分</label>
           <input
             id="servings"
@@ -134,7 +193,7 @@ export default function RecipeForm({ mode, initial, submitting, onSubmit, onCanc
         </div>
       </div>
 
-      <div className="form-group">
+      <div className={`form-group${errors.ingredients ? " has-error" : ""}`} ref={ingredientsRef} tabIndex={-1}>
         <label className="required">材料</label>
         <div>
           {ingredients.map((row, idx) => (
@@ -144,6 +203,7 @@ export default function RecipeForm({ mode, initial, submitting, onSubmit, onCanc
                 placeholder="材料名"
                 value={row.name}
                 onChange={(e) => updateIngredient(idx, { name: e.target.value })}
+                onKeyDown={(e) => handleIngredientKeyDown(e, idx)}
               />
               <input
                 type="text"
@@ -164,7 +224,7 @@ export default function RecipeForm({ mode, initial, submitting, onSubmit, onCanc
               <button
                 type="button"
                 className="btn-link"
-                onClick={() => setIngredients((rows) => rows.filter((_, i) => i !== idx))}
+                onClick={() => setIngredients((rows) => (rows.length === 1 ? [{ name: "", amount: "", unit: "" }] : rows.filter((_, i) => i !== idx)))}
               >
                 削除
               </button>
@@ -184,7 +244,7 @@ export default function RecipeForm({ mode, initial, submitting, onSubmit, onCanc
         </datalist>
       </div>
 
-      <div className="form-group">
+      <div className={`form-group${errors.steps ? " has-error" : ""}`} ref={stepsRef} tabIndex={-1}>
         <label className="required">手順</label>
         <div>
           {steps.map((row, idx) => (
@@ -195,11 +255,12 @@ export default function RecipeForm({ mode, initial, submitting, onSubmit, onCanc
                 placeholder="手順"
                 value={row.description}
                 onChange={(e) => updateStep(idx, e.target.value)}
+                onKeyDown={(e) => handleStepKeyDown(e, idx)}
               />
               <button
                 type="button"
                 className="btn-link"
-                onClick={() => setSteps((rows) => rows.filter((_, i) => i !== idx))}
+                onClick={() => setSteps((rows) => (rows.length === 1 ? [{ description: "" }] : rows.filter((_, i) => i !== idx)))}
               >
                 削除
               </button>

--- a/frontend/pages/recipes/[id].tsx
+++ b/frontend/pages/recipes/[id].tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
+import Breadcrumb from "@/components/Breadcrumb";
 import { api, type Recipe } from "@/lib/api";
 import { formatAmount } from "@/lib/constants";
 
@@ -42,7 +43,7 @@ export default function RecipeDetailPage() {
   if (state.status === "loading") {
     return (
       <>
-        <Link href="/recipes" className="back-link">← 一覧へ戻る</Link>
+        <Breadcrumb href="/recipes" />
         <div className="empty">読み込み中...</div>
       </>
     );
@@ -51,7 +52,7 @@ export default function RecipeDetailPage() {
   if (state.status === "notFound" || !recipe) {
     return (
       <>
-        <Link href="/recipes" className="back-link">← 一覧へ戻る</Link>
+        <Breadcrumb href="/recipes" />
         <div className="empty">レシピが見つかりません</div>
       </>
     );
@@ -59,7 +60,7 @@ export default function RecipeDetailPage() {
 
   return (
     <>
-      <Link href="/recipes" className="back-link">← 一覧へ戻る</Link>
+      <Breadcrumb href="/recipes" />
 
       <div className="detail-header">
         <h2>{recipe.title}</h2>
@@ -75,7 +76,7 @@ export default function RecipeDetailPage() {
       </div>
       <hr className="divider" />
 
-      <div className="section-title">【材料】</div>
+      <h3 className="section-title">材料</h3>
       <ul className="ingredients-list">
         {(recipe.ingredients ?? []).map((i, idx) => (
           <li key={idx}>
@@ -85,7 +86,7 @@ export default function RecipeDetailPage() {
         ))}
       </ul>
 
-      <div className="section-title">【手順】</div>
+      <h3 className="section-title">作り方</h3>
       <ol className="steps-list">
         {(recipe.steps ?? []).map((s, idx) => (
           <li key={idx}>{s.description}</li>
@@ -94,7 +95,7 @@ export default function RecipeDetailPage() {
 
       {recipe.memo && (
         <>
-          <div className="section-title">【メモ】</div>
+          <h3 className="section-title">メモ</h3>
           <div className="memo-box">{recipe.memo}</div>
         </>
       )}
@@ -104,11 +105,11 @@ export default function RecipeDetailPage() {
           <div className="modal">
             <p>このレシピを削除しますか?</p>
             <div className="modal-actions">
-              <button className="btn" onClick={() => setConfirming(false)} disabled={deleting}>
+              <button className="btn btn-strong" onClick={() => setConfirming(false)} disabled={deleting}>
                 キャンセル
               </button>
-              <button className="btn btn-primary" onClick={handleDelete} disabled={deleting}>
-                {deleting ? "削除中..." : "OK"}
+              <button className="btn btn-danger-solid" onClick={handleDelete} disabled={deleting}>
+                {deleting ? "削除中..." : "削除する"}
               </button>
             </div>
           </div>

--- a/frontend/pages/recipes/[id]/edit.tsx
+++ b/frontend/pages/recipes/[id]/edit.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
-import Link from "next/link";
 import { useRouter } from "next/router";
+import Breadcrumb from "@/components/Breadcrumb";
 import RecipeForm from "@/components/RecipeForm";
 import { api, ApiError, type Recipe, type RecipeInput } from "@/lib/api";
 
@@ -39,23 +39,33 @@ export default function EditRecipePage() {
     }
   }
 
-  if (state.status === "loading") return <div className="empty">読み込み中...</div>;
+  if (state.status === "loading") {
+    return (
+      <>
+        <Breadcrumb href="/recipes" />
+        <div className="empty">読み込み中...</div>
+      </>
+    );
+  }
   if (state.status === "notFound" || !recipe) {
     return (
       <>
-        <Link href="/recipes" className="back-link">← 一覧へ戻る</Link>
+        <Breadcrumb href="/recipes" />
         <div className="empty">レシピが見つかりません</div>
       </>
     );
   }
 
   return (
-    <RecipeForm
-      mode="edit"
-      initial={recipe}
-      submitting={submitting}
-      onSubmit={handleSubmit}
-      onCancel={() => router.push(`/recipes/${recipe.id}`)}
-    />
+    <>
+      <Breadcrumb href={`/recipes/${recipe.id}`} label="← 詳細へ戻る" />
+      <RecipeForm
+        mode="edit"
+        initial={recipe}
+        submitting={submitting}
+        onSubmit={handleSubmit}
+        onCancel={() => router.push(`/recipes/${recipe.id}`)}
+      />
+    </>
   );
 }

--- a/frontend/pages/recipes/index.tsx
+++ b/frontend/pages/recipes/index.tsx
@@ -5,8 +5,18 @@ import { CATEGORIES } from "@/lib/constants";
 
 type Sort = "created_desc" | "name_asc";
 
+function formatUpdatedAt(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}/${m}/${day}`;
+}
+
 export default function RecipeListPage() {
   const [keyword, setKeyword] = useState("");
+  const [debouncedKeyword, setDebouncedKeyword] = useState("");
   const [category, setCategory] = useState("");
   const [sort, setSort] = useState<Sort>("created_desc");
   type State =
@@ -16,9 +26,14 @@ export default function RecipeListPage() {
   const [state, setState] = useState<State>({ status: "loading" });
 
   useEffect(() => {
+    const t = setTimeout(() => setDebouncedKeyword(keyword), 300);
+    return () => clearTimeout(t);
+  }, [keyword]);
+
+  useEffect(() => {
     let cancelled = false;
     api
-      .list({ keyword: keyword || undefined, category: category || undefined, sort })
+      .list({ keyword: debouncedKeyword || undefined, category: category || undefined, sort })
       .then((list) => {
         if (!cancelled) setState({ status: "success", recipes: list });
       })
@@ -30,9 +45,9 @@ export default function RecipeListPage() {
     return () => {
       cancelled = true;
     };
-  }, [keyword, category, sort]);
+  }, [debouncedKeyword, category, sort]);
 
-  const filtered = !keyword && !category;
+  const filtered = !debouncedKeyword && !category;
   const emptyMessage = filtered ? "レシピがありません" : "該当するレシピがありません";
 
   return (
@@ -60,9 +75,6 @@ export default function RecipeListPage() {
           <option value="created_desc">新しい順</option>
           <option value="name_asc">名前順</option>
         </select>
-
-        <span className="spacer"></span>
-        <Link href="/recipes/new" className="btn btn-primary">+ 新規登録</Link>
       </div>
 
       <hr className="divider" />
@@ -75,14 +87,21 @@ export default function RecipeListPage() {
         <div className="empty">{emptyMessage}</div>
       ) : (
         <div className="recipe-list">
-          {state.recipes.map((r) => (
-            <Link key={r.id} href={`/recipes/${r.id}`} className="recipe-card">
-              <div className="title">{r.title}</div>
-              <div className="meta">
-                {r.category || "未分類"} / {r.cooking_time ? `${r.cooking_time}分` : "-"}
-              </div>
-            </Link>
-          ))}
+          {state.recipes.map((r) => {
+            const ingCount = r.ingredients?.length ?? 0;
+            return (
+              <Link key={r.id} href={`/recipes/${r.id}`} className="recipe-card">
+                <span className="category-tag">{r.category || "未分類"}</span>
+                <div className="title">{r.title}</div>
+                <div className="meta">
+                  <span className="meta-item">🍴 {r.servings ? `${r.servings}人分` : "-"}</span>
+                  <span className="meta-item">⏱ {r.cooking_time ? `${r.cooking_time}分` : "-"}</span>
+                  <span className="meta-item">🥕 {ingCount}品</span>
+                </div>
+                <div className="updated-at">更新: {formatUpdatedAt(r.updated_at)}</div>
+              </Link>
+            );
+          })}
         </div>
       )}
     </>

--- a/frontend/pages/recipes/new.tsx
+++ b/frontend/pages/recipes/new.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useRouter } from "next/router";
+import Breadcrumb from "@/components/Breadcrumb";
 import RecipeForm from "@/components/RecipeForm";
 import { api, ApiError, type RecipeInput } from "@/lib/api";
 
@@ -20,11 +21,14 @@ export default function NewRecipePage() {
   }
 
   return (
-    <RecipeForm
-      mode="new"
-      submitting={submitting}
-      onSubmit={handleSubmit}
-      onCancel={() => router.push("/recipes")}
-    />
+    <>
+      <Breadcrumb href="/recipes" />
+      <RecipeForm
+        mode="new"
+        submitting={submitting}
+        onSubmit={handleSubmit}
+        onCancel={() => router.push("/recipes")}
+      />
+    </>
   );
 }

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -49,6 +49,14 @@ a:hover {
   text-decoration: none;
   color: var(--accent);
 }
+.header-inner {
+  max-width: 880px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
 
 .container {
   max-width: 880px;
@@ -142,6 +150,19 @@ textarea:focus {
   background: var(--danger);
   color: white;
 }
+.btn-danger-solid {
+  background: var(--danger);
+  border-color: var(--danger);
+  color: white;
+}
+.btn-danger-solid:hover {
+  background: var(--danger-hover);
+  border-color: var(--danger-hover);
+}
+.btn-strong {
+  font-weight: 600;
+  border-color: var(--text);
+}
 .btn-link {
   background: none;
   border: none;
@@ -171,12 +192,14 @@ textarea:focus {
 }
 
 .recipe-list {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
 }
 .recipe-card {
-  display: block;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 8px;
@@ -193,11 +216,32 @@ textarea:focus {
 .recipe-card .title {
   font-size: 16px;
   font-weight: 600;
-  margin-bottom: 4px;
+}
+.recipe-card .category-tag {
+  display: inline-block;
+  font-size: 12px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: #f4f1ea;
+  color: var(--muted);
+  align-self: flex-start;
 }
 .recipe-card .meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
   font-size: 13px;
   color: var(--muted);
+}
+.recipe-card .meta .meta-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.recipe-card .updated-at {
+  font-size: 11px;
+  color: var(--muted);
+  margin-top: auto;
 }
 
 .empty {
@@ -308,9 +352,16 @@ hr.divider {
   resize: vertical;
 }
 .form-row {
-  display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
+  display: flex;
+  flex-wrap: wrap;
   gap: 16px;
+}
+.form-row .form-group {
+  margin-bottom: 0;
+  flex: 1 1 160px;
+}
+.form-row .form-group.numeric {
+  flex: 0 0 120px;
 }
 .form-row input[type="number"] {
   width: 100%;
@@ -347,6 +398,25 @@ hr.divider {
   font-size: 12px;
   margin-top: 4px;
   min-height: 16px;
+}
+
+.has-error input[type="text"],
+.has-error select,
+.has-error textarea,
+input.has-error,
+select.has-error,
+textarea.has-error {
+  border-color: var(--danger);
+  outline-color: var(--danger);
+}
+.has-error input[type="text"]:focus,
+.has-error select:focus,
+.has-error textarea:focus,
+input.has-error:focus,
+select.has-error:focus,
+textarea.has-error:focus {
+  outline: 2px solid var(--danger);
+  border-color: var(--danger);
 }
 
 .form-actions {


### PR DESCRIPTION
## Summary

開発計画書 Phase 6 の UI 改善 9 件を実装。

### 高インパクト
- 1. フォームバリデーションの可視化（`.has-error` 赤枠 / onChange 解除 / 最初のエラーへ `scrollIntoView`）
- 2. 一覧カードを CSS Grid でレスポンシブ化（🍴人数 / ⏱時間 / 🥕材料数 / 更新日）
- 3. 検索キーワードを 300ms デバウンス

### 中インパクト
- 4. 削除確認モーダルを danger 反転（「削除する」赤ソリッドボタン、キャンセル太字）
- 5. 戻る導線を `components/Breadcrumb.tsx` で統一（詳細・新規・編集）
- 6. 材料/手順の追従型 UX（末尾行入力で空行を自動追加、Enter で次行追加）

### 低インパクト
- 7. 数値入力欄を `flex: 0 0 120px`、カテゴリは可変
- 8. 詳細画面の見出しを `<h3>` の「材料 / 作り方 / メモ」へフラット化
- 9. ヘッダー右側に常設「+ 新規登録」ボタン（新規登録画面では非表示）

## Quality

- `npm run lint` / `npm run typecheck` / `npm run build` すべて pass
- ブラウザで全画面の手動確認済み（一覧グリッド・デバウンス・赤枠・削除モーダル・戻る導線・追従行追加）

## Test plan

- [ ] `/recipes` を開きカードがグリッドで表示される
- [ ] 検索欄でタイピング中に通信がデバウンスされる
- [ ] 詳細画面の削除ボタン → モーダルが赤ボタン「削除する」になっている
- [ ] 新規登録で空送信し、エラー入力欄が赤枠 / 最初のエラーへスクロール
- [ ] 材料/手順の末尾行に入力すると空行が自動追加される
- [ ] ヘッダー右上の「+ 新規登録」が常設されている

Closes #21