### PR TITLE
docs: frontend / backend README をプロジェクト固有内容に書き換え

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,24 +1,96 @@
-# README
+# RecipeManager Backend
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+RecipeManager のバックエンド（Ruby on Rails 8.1.3 / API mode / MySQL 8.0）。プロジェクト全体については [../README.md](../README.md) を参照。
 
-Things you may want to cover:
+## スタック
 
-* Ruby version
+- Ruby 3.4.9（`.ruby-version` で固定 / rbenv 管理）
+- Rails 8.1.3 (**API mode** — view レイヤなし、JSON のみ返す)
+- MySQL 8.0
+- CORS: `rack-cors` で `http://localhost:3000` を許可
 
-* System dependencies
+## ディレクトリ構成
 
-* Configuration
+```
+backend/
+├── app/
+│   ├── controllers/api/      # Api::RecipesController（index/show/create/update/destroy）
+│   └── models/recipe.rb      # title 必須・100 字、category inclusion
+├── config/
+│   ├── routes.rb             # namespace :api { resources :recipes }
+│   ├── database.yml          # 接続先（環境変数経由）
+│   └── initializers/cors.rb  # CORS 設定
+├── db/
+│   ├── migrate/              # recipes テーブル
+│   ├── schema.rb
+│   └── seeds.rb
+├── Dockerfile.dev            # 開発用（docker-compose で利用）
+└── .env.example              # DB_USERNAME / DB_PASSWORD / DB_HOST
+```
 
-* Database creation
+## API エンドポイント
 
-* Database initialization
+ベース URL: `/api`
 
-* How to run the test suite
+| メソッド | パス | 用途 |
+| --- | --- | --- |
+| `GET`    | `/api/recipes` | 一覧（クエリ: `keyword` 部分一致 / `category` 完全一致 / `sort=created_desc\|name_asc`） |
+| `GET`    | `/api/recipes/:id` | 詳細 |
+| `POST`   | `/api/recipes` | 新規作成（`{ "recipe": {...} }` でラップ） |
+| `PATCH`  | `/api/recipes/:id` | 更新（部分更新可） |
+| `DELETE` | `/api/recipes/:id` | 削除（204 No Content） |
 
-* Services (job queues, cache servers, search engines, etc.)
+エラーは 422（バリデーション）/ 404（未存在）を JSON で返す。仕様の詳細は [../docs/機能仕様書.md](../docs/機能仕様書.md) を参照。
 
-* Deployment instructions
+## セットアップ
 
-* ...
+```bash
+bundle install
+cp .env.example .env             # DB_USERNAME / DB_PASSWORD / DB_HOST を設定
+bin/rails db:create db:migrate
+```
+
+主な環境変数:
+
+| 変数 | 用途 |
+| --- | --- |
+| `DB_USERNAME` | MySQL ユーザ名 |
+| `DB_PASSWORD` | MySQL パスワード |
+| `DB_HOST` | MySQL ホスト（ローカル: `127.0.0.1` / docker compose: `db`） |
+
+## 起動
+
+```bash
+bin/rails s -p 3001
+```
+
+ポートは **3001 固定**（Next.js が 3000 を使うため）。占有時は別ポートに逃げず、占有プロセスを停止して規定ポートで起動し直す（[../CLAUDE.md](../CLAUDE.md) のポート運用ルール）。
+
+### Docker Compose で起動する場合
+
+ルートで:
+
+```bash
+docker compose up -d
+docker compose exec backend bin/rails db:create db:migrate   # 初回のみ
+```
+
+## 主要コマンド
+
+| コマンド | 内容 |
+| --- | --- |
+| `bin/rails s -p 3001` | API サーバ起動 |
+| `bin/rails c` | Rails コンソール |
+| `bin/rails db:migrate` | マイグレーション適用 |
+| `bin/rails db:rollback` | 直前のマイグレーションを戻す |
+| `bin/rails routes \| grep recipes` | ルーティング確認 |
+
+## 動作確認
+
+```bash
+curl http://localhost:3001/api/recipes
+curl http://localhost:3001/api/recipes/1
+curl -X POST http://localhost:3001/api/recipes \
+  -H 'Content-Type: application/json' \
+  -d '{"recipe":{"title":"テスト","category":"和食","ingredients":[{"name":"米","amount":"2","unit":"合"}],"steps":[{"order":1,"description":"研ぐ"}]}}'
+```

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,40 +1,71 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/pages/api-reference/create-next-app).
+# RecipeManager Frontend
 
-## Getting Started
+RecipeManager のフロントエンド（Next.js 16 / Pages Router / TypeScript）。プロジェクト全体については [../README.md](../README.md) を参照。
 
-First, run the development server:
+## スタック
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+- Next.js 16 (**Pages Router** — App Router ではない)
+- React 19 / TypeScript 5
+- ESLint (`eslint-config-next`)
+- Volta によるツールチェイン固定（Node 22 / npm 11）
+
+## ディレクトリ構成
+
+```
+frontend/
+├── components/   # Header / Layout / Breadcrumb / RecipeForm
+├── lib/          # api.ts (API クライアント) / constants.ts (カテゴリ・単位 enum 等)
+├── pages/        # _app.tsx / _document.tsx / index.tsx / recipes/
+├── styles/       # globals.css / Home.module.css
+└── public/       # 静的アセット
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+## 主要ファイル
 
-You can start editing the page by modifying `pages/index.tsx`. The page auto-updates as you edit the file.
+| ファイル | 役割 |
+| --- | --- |
+| [`lib/api.ts`](lib/api.ts) | API 呼び出しの中央集約。`api.list / get / create / update / destroy` を提供。`NEXT_PUBLIC_API_BASE` を読む。更新は `PATCH` |
+| [`lib/constants.ts`](lib/constants.ts) | カテゴリ enum (`和食/洋食/中華/その他`)、単位候補、調理時間候補、何人分候補、半角化ヘルパ |
+| [`components/RecipeForm.tsx`](components/RecipeForm.tsx) | 登録/編集の共通フォーム。バリデーション・動的行追加（Enter / 自動空行）・エラー赤枠・`scrollIntoView` を実装 |
+| [`components/Header.tsx`](components/Header.tsx) | ヘッダー。右側に「+ 新規登録」ボタンを常設（`/recipes/new` 表示時は非表示） |
+| [`components/Breadcrumb.tsx`](components/Breadcrumb.tsx) | 戻る導線。詳細→一覧 / 編集→詳細を文脈に応じて切り替え |
+| [`pages/index.tsx`](pages/index.tsx) | `/` から `/recipes` へリダイレクト |
+| [`pages/recipes/index.tsx`](pages/recipes/index.tsx) | 一覧（CSS Grid / 検索 300ms デバウンス / カテゴリ絞り込み / 並び順） |
 
-[API routes](https://nextjs.org/docs/pages/building-your-application/routing/api-routes) can be accessed on [http://localhost:3000/api/hello](http://localhost:3000/api/hello). This endpoint can be edited in `pages/api/hello.ts`.
+## セットアップ
 
-The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/pages/building-your-application/routing/api-routes) instead of React pages.
+```bash
+npm install
+cp .env.local.example .env.local   # NEXT_PUBLIC_API_BASE を確認
+```
 
-This project uses [`next/font`](https://nextjs.org/docs/pages/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+主な環境変数:
 
-## Learn More
+| 変数 | 既定値 | 用途 |
+| --- | --- | --- |
+| `NEXT_PUBLIC_API_BASE` | `http://localhost:3001/api` | Rails API のベース URL |
 
-To learn more about Next.js, take a look at the following resources:
+## 起動
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn-pages-router) - an interactive Next.js tutorial.
+```bash
+npm run dev      # http://localhost:3000
+```
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+ポートは **3000 固定**。占有時は別ポートに逃げず、占有プロセスを停止して規定ポートで起動し直す（[../CLAUDE.md](../CLAUDE.md) のポート運用ルール）。
 
-## Deploy on Vercel
+バックエンド (Rails API) を `http://localhost:3001` で起動しておく必要がある。手順は [../backend/README.md](../backend/README.md) を参照。
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+## npm スクリプト
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/pages/building-your-application/deploying) for more details.
+| コマンド | 内容 |
+| --- | --- |
+| `npm run dev` | 開発サーバ起動（ホットリロード） |
+| `npm run build` | プロダクションビルド |
+| `npm run start` | ビルド成果物の起動 |
+| `npm run lint` | ESLint |
+| `npm run typecheck` | `tsc --noEmit` |
+
+## エージェント向けドキュメント
+
+- [AGENTS.md](AGENTS.md) — Next.js 16 はバージョンアップで破壊的変更があるため、コードを書く前に `node_modules/next/dist/docs/` 配下のガイドを参照する旨の注意
+- [CLAUDE.md](CLAUDE.md) — `AGENTS.md` への薄いリダイレクト


### PR DESCRIPTION
## Summary
`create-next-app` / `rails new` のデフォルトテンプレートのままだった `frontend/README.md` と `backend/README.md` を、RecipeManager 固有の情報に書き換え。

### frontend/README.md
- スタック（Next.js 16 / Pages Router / TypeScript / Volta）
- ディレクトリ構成と主要ファイル（`lib/api.ts`、`lib/constants.ts`、`components/RecipeForm.tsx`、`Header.tsx`、`Breadcrumb.tsx`、`pages/index.tsx`、`pages/recipes/index.tsx`）
- セットアップ / 環境変数（`NEXT_PUBLIC_API_BASE`）
- ポート 3000 固定 / 別ポート禁止
- npm スクリプト一覧（dev / build / start / lint / typecheck）
- AGENTS.md（Next.js 16 の破壊的変更注意）への言及

### backend/README.md
- スタック（Rails 8.1.3 API mode / MySQL 8.0 / CORS）
- ディレクトリ構成
- API エンドポイント表（GET/POST/PATCH/DELETE `/api/recipes[/:id]`）
- セットアップ / 環境変数（DB_USERNAME / DB_PASSWORD / DB_HOST）
- ポート 3001 固定（Next.js との衝突回避）
- 主要 rails コマンド（s / c / db:migrate / routes）
- curl での動作確認例

## Test plan
- [ ] `frontend/README.md` の手順で Next.js dev が 3000 で立ち上がる
- [ ] `backend/README.md` の手順で Rails API が 3001 で立ち上がる
- [ ] ルート README とコマンド・ポートが矛盾していない
- [ ] テンプレート由来の記述が残っていない

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)