### PR TITLE
feat: AWS デプロイ環境構築（Terraform + ghcr.io + Docker Compose）

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,52 @@
+.PHONY: build build-backend build-frontend release deploy redeploy destroy ssh logs status
+
+GHCR_REPO := ghcr.io/hiroyuki-12/recipemanager
+BACKEND_IMAGE := $(GHCR_REPO)-backend:latest
+FRONTEND_IMAGE := $(GHCR_REPO)-frontend:latest
+
+# バックエンド Docker イメージをローカルでビルド
+build-backend:
+	docker build -t $(BACKEND_IMAGE) ./backend
+	@echo "Built $(BACKEND_IMAGE)"
+
+# フロントエンド Docker イメージをローカルでビルド
+build-frontend:
+	docker build -t $(FRONTEND_IMAGE) ./frontend
+	@echo "Built $(FRONTEND_IMAGE)"
+
+# 両方ビルド
+build: build-backend build-frontend
+
+# ghcr.io にプッシュ (事前に: echo $GITHUB_TOKEN | docker login ghcr.io -u Hiroyuki-12 --password-stdin)
+release: build
+	docker push $(BACKEND_IMAGE)
+	docker push $(FRONTEND_IMAGE)
+	@echo "Pushed to ghcr.io"
+
+# 初回デプロイ
+deploy:
+	cd infra && terraform apply
+
+# EC2 だけ作り直し (新しいイメージを反映させたい時)
+redeploy:
+	cd infra && terraform apply -replace=aws_instance.app
+
+# 全リソース削除
+destroy:
+	cd infra && terraform destroy
+
+# EC2 へ SSH
+ssh:
+	@cd infra && eval $$(terraform output -raw ssh_command)
+
+# コンテナログ
+logs:
+	@DNS=$$(cd infra && terraform output -raw ec2_public_dns); \
+	ssh -i ~/.ssh/recipemanager-key.pem ec2-user@$$DNS \
+	  'cd /opt/recipemanager && sudo docker compose -f compose.prod.yaml logs --tail=100 -f'
+
+# コンテナ・nginx の状態確認
+status:
+	@DNS=$$(cd infra && terraform output -raw ec2_public_dns); \
+	ssh -i ~/.ssh/recipemanager-key.pem ec2-user@$$DNS \
+	  'cd /opt/recipemanager && sudo docker compose -f compose.prod.yaml ps; echo; sudo systemctl is-active nginx'

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -1,0 +1,23 @@
+services:
+  backend:
+    image: ghcr.io/hiroyuki-12/recipemanager-backend:latest
+    container_name: recipemanager-backend
+    restart: unless-stopped
+    environment:
+      RAILS_ENV: production
+      DATABASE_URL: mysql2://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}
+      RAILS_MASTER_KEY: ${RAILS_MASTER_KEY}
+      RAILS_LOG_TO_STDOUT: "true"
+    ports:
+      - "3001:80"
+
+  frontend:
+    image: ghcr.io/hiroyuki-12/recipemanager-frontend:latest
+    container_name: recipemanager-frontend
+    restart: unless-stopped
+    environment:
+      NODE_ENV: production
+      PORT: "3000"
+      # NEXT_PUBLIC_* はビルド時に埋め込み済みのため実行時設定不要
+    ports:
+      - "3000:3000"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,36 @@
+# syntax=docker/dockerfile:1
+
+ARG NODE_VERSION=22
+
+FROM node:${NODE_VERSION}-alpine AS builder
+WORKDIR /app
+
+# NEXT_PUBLIC_* はビルド時にバンドルへ埋め込まれるため ARG で受け取る
+# デフォルト /api は本番 nginx が /api/* を Rails にプロキシする前提
+ARG NEXT_PUBLIC_API_BASE=/api
+ENV NEXT_PUBLIC_API_BASE=${NEXT_PUBLIC_API_BASE}
+
+COPY package*.json ./
+RUN npm ci --no-audit --no-fund
+
+COPY . .
+RUN npm run build
+
+FROM node:${NODE_VERSION}-alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production \
+    PORT=3000 \
+    HOSTNAME=0.0.0.0
+
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 nextjs
+
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+
+USER nextjs
+
+EXPOSE 3000
+CMD ["node", "server.js"]

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,8 +1,8 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
   reactStrictMode: true,
+  output: "standalone",
 };
 
 export default nextConfig;

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,148 @@
+# AWS デプロイ手順
+
+RecipeManager を AWS (EC2 + RDS MySQL) にデプロイするための手順です。
+
+## アーキテクチャ
+
+```
+nginx (port 80)
+  ├── /api/* → Rails API container (port 3001)
+  └── /*     → Next.js container  (port 3000)
+
+RDS MySQL 8.0 (db.t3.micro, private subnet)
+EC2 t2.micro (Amazon Linux 2023, public subnet)
+```
+
+EC2 上でのビルドは行わず、**ローカルでビルドした Docker イメージを ghcr.io にプッシュ → EC2 は pull して起動するだけ**にしています（t2.micro の OOM 対策）。
+
+## 前提条件
+
+- AWS CLI 設定済み (`aws configure`)
+- Terraform >= 1.9 インストール済み
+- Docker Desktop 起動済み
+- `gh` CLI 認証済み (`gh auth login`)
+- GitHub PAT (Scopes: `write:packages`, `read:packages`) を取得済み
+
+## セットアップ手順
+
+### 1. Terraform バックエンド用 S3 + DynamoDB を作成（初回のみ）
+
+```bash
+# S3 バケット
+aws s3api create-bucket \
+  --bucket recipemanager-tfstate \
+  --region ap-northeast-1 \
+  --create-bucket-configuration LocationConstraint=ap-northeast-1
+
+aws s3api put-bucket-versioning \
+  --bucket recipemanager-tfstate \
+  --versioning-configuration Status=Enabled
+
+aws s3api put-public-access-block \
+  --bucket recipemanager-tfstate \
+  --public-access-block-configuration \
+    BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true
+
+# DynamoDB テーブル
+aws dynamodb create-table \
+  --table-name recipemanager-tflock \
+  --attribute-definitions AttributeName=LockID,AttributeType=S \
+  --key-schema AttributeName=LockID,KeyType=HASH \
+  --billing-mode PAY_PER_REQUEST \
+  --region ap-northeast-1
+```
+
+### 2. EC2 SSH キーペアを作成
+
+```bash
+aws ec2 create-key-pair \
+  --key-name recipemanager-key \
+  --region ap-northeast-1 \
+  --query 'KeyMaterial' \
+  --output text > ~/.ssh/recipemanager-key.pem
+chmod 400 ~/.ssh/recipemanager-key.pem
+```
+
+### 3. terraform.tfvars を作成
+
+```bash
+cp infra/terraform.tfvars.example infra/terraform.tfvars
+# エディタで各値を設定
+```
+
+`my_ip` は `curl ifconfig.me` で確認した自宅 IP を `/32` 付きで設定します。  
+`rails_master_key` は `cat backend/config/master.key` の値を設定します。
+
+### 4. ghcr.io へのログイン
+
+```bash
+echo $GITHUB_TOKEN | docker login ghcr.io -u Hiroyuki-12 --password-stdin
+```
+
+### 5. イメージをビルド＆プッシュ
+
+```bash
+make release
+```
+
+### 6. Terraform 初期化＆デプロイ
+
+```bash
+cd infra && terraform init
+cd ..
+make deploy
+```
+
+`terraform apply` 完了後、EC2 の初期化に 3〜5 分かかります。
+
+### 7. 動作確認
+
+```bash
+# EC2 の IP を確認
+cd infra && terraform output app_url
+
+# SSH でコンテナ状態を確認
+make status
+
+# ブラウザで確認
+open $(cd infra && terraform output -raw app_url)
+```
+
+## 再デプロイ（コード更新時）
+
+```bash
+make release   # イメージを再ビルド＆プッシュ
+make redeploy  # EC2 を作り直して最新イメージを取得
+```
+
+## トラブルシューティング
+
+### コンテナが起動しない
+
+```bash
+make ssh
+sudo docker compose -f /opt/recipemanager/compose.prod.yaml logs
+```
+
+### nginx が 502 を返す
+
+コンテナの起動を待っている可能性があります。30 秒待ってからリロードしてください。
+
+```bash
+make status
+```
+
+### user_data の実行ログを確認
+
+```bash
+make ssh
+sudo cat /var/log/cloud-init-output.log
+```
+
+## リソース削除
+
+```bash
+make destroy
+```
+
+その後、S3 バケットと DynamoDB テーブルも不要なら手動で削除してください。

--- a/infra/backend.tf
+++ b/infra/backend.tf
@@ -1,0 +1,25 @@
+# S3 バックエンド設定は providers.tf の terraform ブロック内で定義しています。
+# このファイルは S3 バケットと DynamoDB テーブルの事前作成手順を示す参考コメントです。
+#
+# 初回セットアップ時に以下を手動で実行してください:
+#
+# aws s3api create-bucket \
+#   --bucket recipemanager-tfstate \
+#   --region ap-northeast-1 \
+#   --create-bucket-configuration LocationConstraint=ap-northeast-1
+#
+# aws s3api put-bucket-versioning \
+#   --bucket recipemanager-tfstate \
+#   --versioning-configuration Status=Enabled
+#
+# aws s3api put-public-access-block \
+#   --bucket recipemanager-tfstate \
+#   --public-access-block-configuration \
+#     BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true
+#
+# aws dynamodb create-table \
+#   --table-name recipemanager-tflock \
+#   --attribute-definitions AttributeName=LockID,AttributeType=S \
+#   --key-schema AttributeName=LockID,KeyType=HASH \
+#   --billing-mode PAY_PER_REQUEST \
+#   --region ap-northeast-1

--- a/infra/ec2.tf
+++ b/infra/ec2.tf
@@ -1,0 +1,57 @@
+data "aws_ami" "al2023" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-*-x86_64"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+resource "aws_instance" "app" {
+  ami                         = data.aws_ami.al2023.id
+  instance_type               = "t2.micro"
+  key_name                    = var.key_name
+  subnet_id                   = aws_subnet.public.id
+  vpc_security_group_ids      = [aws_security_group.ec2.id]
+  associate_public_ip_address = true
+
+  user_data = templatefile("${path.module}/user_data.sh.tpl", {
+    db_host          = aws_db_instance.main.address
+    db_port          = aws_db_instance.main.port
+    db_name          = var.db_name
+    db_username      = var.db_username
+    db_password      = var.db_password
+    rails_master_key = var.rails_master_key
+    ghcr_token       = var.ghcr_token
+  })
+  user_data_replace_on_change = true
+
+  depends_on = [aws_db_instance.main]
+
+  metadata_options {
+    http_tokens   = "required"
+    http_endpoint = "enabled"
+  }
+
+  root_block_device {
+    volume_type           = "gp3"
+    volume_size           = 8
+    delete_on_termination = true
+    encrypted             = true
+  }
+
+  tags = {
+    Name = "${var.project}-ec2"
+  }
+}

--- a/infra/network.tf
+++ b/infra/network.tf
@@ -1,0 +1,91 @@
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+resource "aws_vpc" "main" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name = "${var.project}-vpc"
+  }
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${var.project}-igw"
+  }
+}
+
+resource "aws_subnet" "public" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = "10.0.1.0/24"
+  availability_zone       = data.aws_availability_zones.available.names[0]
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "${var.project}-public-1"
+    Tier = "public"
+  }
+}
+
+resource "aws_subnet" "private_a" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.0.11.0/24"
+  availability_zone = data.aws_availability_zones.available.names[0]
+
+  tags = {
+    Name = "${var.project}-private-a"
+    Tier = "private"
+  }
+}
+
+resource "aws_subnet" "private_c" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.0.12.0/24"
+  availability_zone = data.aws_availability_zones.available.names[1]
+
+  tags = {
+    Name = "${var.project}-private-c"
+    Tier = "private"
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = {
+    Name = "${var.project}-public-rt"
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${var.project}-private-rt"
+  }
+}
+
+resource "aws_route_table_association" "private_a" {
+  subnet_id      = aws_subnet.private_a.id
+  route_table_id = aws_route_table.private.id
+}
+
+resource "aws_route_table_association" "private_c" {
+  subnet_id      = aws_subnet.private_c.id
+  route_table_id = aws_route_table.private.id
+}

--- a/infra/nginx.conf
+++ b/infra/nginx.conf
@@ -1,0 +1,26 @@
+server {
+    listen 80 default_server;
+    server_name _;
+
+    # Rails API へのリバースプロキシ
+    location /api/ {
+        proxy_pass http://127.0.0.1:3001;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Next.js (SSR) へのリバースプロキシ
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,24 @@
+output "ec2_public_ip" {
+  description = "EC2 インスタンスのパブリック IP"
+  value       = aws_instance.app.public_ip
+}
+
+output "ec2_public_dns" {
+  description = "EC2 インスタンスのパブリック DNS"
+  value       = aws_instance.app.public_dns
+}
+
+output "ssh_command" {
+  description = "EC2 への SSH コマンド"
+  value       = "ssh -i ~/.ssh/${var.key_name}.pem ec2-user@${aws_instance.app.public_dns}"
+}
+
+output "app_url" {
+  description = "アプリ URL"
+  value       = "http://${aws_instance.app.public_ip}"
+}
+
+output "rds_endpoint" {
+  description = "RDS エンドポイント"
+  value       = aws_db_instance.main.address
+}

--- a/infra/providers.tf
+++ b/infra/providers.tf
@@ -1,0 +1,30 @@
+terraform {
+  required_version = ">= 1.9"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "s3" {
+    bucket         = "recipemanager-tfstate"
+    key            = "prod/terraform.tfstate"
+    region         = "ap-northeast-1"
+    dynamodb_table = "recipemanager-tflock"
+    encrypt        = true
+  }
+}
+
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Project     = var.project
+      Environment = var.environment
+      ManagedBy   = "terraform"
+    }
+  }
+}

--- a/infra/rds.tf
+++ b/infra/rds.tf
@@ -1,0 +1,38 @@
+resource "aws_db_subnet_group" "main" {
+  name       = "${var.project}-db-subnet-group"
+  subnet_ids = [aws_subnet.private_a.id, aws_subnet.private_c.id]
+
+  tags = {
+    Name = "${var.project}-db-subnet-group"
+  }
+}
+
+resource "aws_db_instance" "main" {
+  identifier        = "${var.project}-db"
+  engine            = "mysql"
+  engine_version    = "8.0"
+  instance_class    = "db.t3.micro"
+  allocated_storage = 20
+  storage_type      = "gp3"
+  storage_encrypted = true
+
+  db_name  = var.db_name
+  username = var.db_username
+  password = var.db_password
+  port     = 3306
+
+  db_subnet_group_name   = aws_db_subnet_group.main.name
+  vpc_security_group_ids = [aws_security_group.db.id]
+  publicly_accessible    = false
+  multi_az               = false
+
+  backup_retention_period    = 1
+  skip_final_snapshot        = true
+  deletion_protection        = false
+  auto_minor_version_upgrade = true
+  apply_immediately          = true
+
+  tags = {
+    Name = "${var.project}-db"
+  }
+}

--- a/infra/security.tf
+++ b/infra/security.tf
@@ -1,0 +1,59 @@
+resource "aws_security_group" "ec2" {
+  name        = "${var.project}-ec2"
+  description = "RecipeManager EC2: SSH and HTTP from my_ip only"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description = "SSH from my_ip"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [var.my_ip]
+  }
+
+  ingress {
+    description = "HTTP from my_ip"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = [var.my_ip]
+  }
+
+  egress {
+    description = "All outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.project}-ec2-sg"
+  }
+}
+
+resource "aws_security_group" "db" {
+  name        = "${var.project}-db"
+  description = "RDS MySQL: allow 3306 only from EC2 SG"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description     = "MySQL from EC2"
+    from_port       = 3306
+    to_port         = 3306
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ec2.id]
+  }
+
+  egress {
+    description = "All outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.project}-db-sg"
+  }
+}

--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -1,0 +1,19 @@
+# このファイルをコピーして terraform.tfvars を作成し、各値を設定してください。
+# terraform.tfvars は .gitignore に含まれており Git 管理外です。
+
+# 自宅 IP アドレス (curl ifconfig.me で確認)
+my_ip = "xxx.xxx.xxx.xxx/32"
+
+# EC2 SSH キーペア名 (AWS に登録済みのもの)
+key_name = "recipemanager-key"
+
+# RDS の DB 名・ユーザー・パスワード
+db_name     = "recipemanager"
+db_username = "recipe_user"
+db_password = "your-strong-password"
+
+# Rails の RAILS_MASTER_KEY (backend/config/master.key の内容)
+rails_master_key = "your-master-key"
+
+# ghcr.io からイメージを pull するための GitHub PAT (read:packages 権限)
+ghcr_token = "ghp_xxxxxxxxxxxxxxxxxxxx"

--- a/infra/user_data.sh.tpl
+++ b/infra/user_data.sh.tpl
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -euxo pipefail
+# Amazon Linux 2023 初期セットアップ:
+#  - Docker / Docker Compose plugin / git / nginx インストール
+#  - ghcr.io からビルド済みイメージを pull (EC2 上でのビルドなし)
+#  - RDS 接続情報・Rails master key を /opt/recipemanager/.env として書き出し
+#  - compose.prod.yaml で Rails + Next.js を起動
+#  - nginx で /api/* を Rails(3001)、/* を Next.js(3000) にリバプロ
+
+# 1. パッケージ
+dnf -y update
+dnf -y install docker git nginx
+
+# 2. Docker
+systemctl enable --now docker
+usermod -aG docker ec2-user
+
+# 3. Docker Compose plugin
+DOCKER_CONFIG_DIR=/usr/libexec/docker/cli-plugins
+mkdir -p "$DOCKER_CONFIG_DIR"
+COMPOSE_VERSION="v2.29.7"
+ARCH="$(uname -m)"
+curl -sSL "https://github.com/docker/compose/releases/download/$${COMPOSE_VERSION}/docker-compose-linux-$${ARCH}" \
+  -o "$DOCKER_CONFIG_DIR/docker-compose"
+chmod +x "$DOCKER_CONFIG_DIR/docker-compose"
+
+# 4. リポジトリ取得
+APP_DIR=/opt/recipemanager
+git clone https://github.com/Hiroyuki-12/RecipeManager.git "$APP_DIR"
+
+# 5. 環境変数ファイルを書き出し
+cat > "$APP_DIR/.env" <<EOF
+DB_HOST=${db_host}
+DB_PORT=${db_port}
+DB_NAME=${db_name}
+DB_USERNAME=${db_username}
+DB_PASSWORD=${db_password}
+RAILS_MASTER_KEY=${rails_master_key}
+EOF
+chmod 600 "$APP_DIR/.env"
+
+chown -R ec2-user:ec2-user "$APP_DIR"
+
+# 6. ghcr.io にログインしてイメージを pull (ビルドなし)
+echo "${ghcr_token}" | docker login ghcr.io -u Hiroyuki-12 --password-stdin
+cd "$APP_DIR"
+docker compose -f compose.prod.yaml pull
+
+# 7. コンテナ起動 (Rails DB マイグレーションは entrypoint で自動実行)
+docker compose -f compose.prod.yaml up -d
+
+# 8. nginx 設定
+rm -f /etc/nginx/conf.d/default.conf
+cp "$APP_DIR/infra/nginx.conf" /etc/nginx/conf.d/recipemanager.conf
+nginx -t
+
+# 9. nginx 起動
+systemctl enable --now nginx

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,58 @@
+variable "project" {
+  description = "プロジェクト識別子。リソース名・タグの prefix に使う"
+  type        = string
+  default     = "recipemanager"
+}
+
+variable "region" {
+  description = "デプロイ先 AWS リージョン"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "environment" {
+  description = "リソースの Environment タグ"
+  type        = string
+  default     = "prod"
+}
+
+variable "my_ip" {
+  description = "SSH / HTTP 接続を許可する自宅 IP (CIDR 形式 例: 203.0.113.10/32)。terraform.tfvars で設定し Git にコミットしないこと"
+  type        = string
+}
+
+variable "key_name" {
+  description = "EC2 にアタッチする SSH キーペア名 (事前に AWS CLI で作成済みのもの)"
+  type        = string
+  default     = "recipemanager-key"
+}
+
+variable "db_name" {
+  description = "RDS の DB 名"
+  type        = string
+  default     = "recipemanager"
+}
+
+variable "db_username" {
+  description = "RDS の master ユーザー"
+  type        = string
+  default     = "recipe_user"
+}
+
+variable "db_password" {
+  description = "RDS の master パスワード (terraform.tfvars で指定、Git 管理外)"
+  type        = string
+  sensitive   = true
+}
+
+variable "rails_master_key" {
+  description = "Rails の RAILS_MASTER_KEY (config/master.key の内容。terraform.tfvars で指定、Git 管理外)"
+  type        = string
+  sensitive   = true
+}
+
+variable "ghcr_token" {
+  description = "ghcr.io からイメージを pull するための GitHub Personal Access Token (read:packages 権限)"
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
## Summary

- `infra/` に Terraform ファイルを追加（VPC/EC2 t2.micro/RDS MySQL 8.0/SG/S3 tfstate backend）
- `compose.prod.yaml` で ghcr.io の Rails + Next.js イメージを pull して起動
- `frontend/Dockerfile` を追加（Next.js standalone マルチステージビルド）
- `frontend/next.config.ts` に `output: 'standalone'` を追加
- `Makefile` に build / release / deploy / redeploy / destroy / ssh / logs / status ターゲットを追加

### OOM 対策
t2.micro (1GB RAM) でのビルドを避けるため、**ローカルでビルドした Docker イメージを ghcr.io にプッシュ → EC2 は `docker pull` して起動するだけ**の構成にした。

### 品質チェックで検出・修正した問題
- `NEXT_PUBLIC_*` 変数は `next build` 時にバンドルへ埋め込まれるためランタイム環境変数では変更不可 → `frontend/Dockerfile` の builder ステージで `ARG NEXT_PUBLIC_API_BASE=/api` として設定
- 変数名の不一致（`NEXT_PUBLIC_API_BASE_URL` → `NEXT_PUBLIC_API_BASE`）を修正

## Test plan

- [ ] `make build` でローカルビルドが成功することを確認
- [ ] `make release` で ghcr.io へのプッシュが成功することを確認
- [ ] Terraform セットアップ後 `make deploy` で EC2/RDS が起動することを確認
- [ ] `make status` でコンテナ 2 つと nginx が起動していることを確認
- [ ] `http://<EC2_IP>` でアプリが表示されることを確認

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)