### PR TITLE
fix: Terraform backend の dynamodb_table を use_lockfile に更新

### DIFF
--- a/infra/providers.tf
+++ b/infra/providers.tf
@@ -12,7 +12,7 @@ terraform {
     bucket         = "recipemanager-tfstate"
     key            = "prod/terraform.tfstate"
     region         = "ap-northeast-1"
-    dynamodb_table = "recipemanager-tflock"
+    use_lockfile   = true
     encrypt        = true
   }
 }


### PR DESCRIPTION
## Summary
- Terraform 1.15 で `dynamodb_table` パラメータが非推奨となったため `use_lockfile = true` に変更

## Test plan
- [ ] `terraform init` で警告が出ないことを確認

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)