### PR TITLE
fix: compose.prod.yaml に DB 個別環境変数を追加

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -6,6 +6,11 @@ services:
     environment:
       RAILS_ENV: production
       DATABASE_URL: mysql2://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}
+      DB_HOST: ${DB_HOST}
+      DB_PORT: ${DB_PORT}
+      DB_NAME: ${DB_NAME}
+      DB_USERNAME: ${DB_USERNAME}
+      DB_PASSWORD: ${DB_PASSWORD}
       RAILS_MASTER_KEY: ${RAILS_MASTER_KEY}
       RAILS_LOG_TO_STDOUT: "true"
     ports:


### PR DESCRIPTION
## Summary
- Rails の `database.yml` は cache/queue/cable DB に `DB_HOST` 等の個別変数を参照するが、`compose.prod.yaml` には `DATABASE_URL` のみを渡しており 127.0.0.1 に接続しようとする問題を修正

## Test plan
- [ ] `make redeploy` 後、Rails コンテナが正常起動することを確認
- [ ] `/api/recipes` が 200 を返すことを確認

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)