### PR TITLE
docs: README にデモ動画を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,7 @@ tfplan
 # Claude Code local state (skills のみチームで共有するため除外しない)
 .claude/*
 !.claude/skills/
+
+# 動画ファイル（GitHub Releases で管理）
+*.mp4
+*.mov

--- a/README.md
+++ b/README.md
@@ -8,12 +8,7 @@
 
 実際の操作を録画したデモ動画です。
 
-<!-- TODO: GitHub Issue/PR にアップロードした動画の user-attachments URL をここに貼る -->
-<!-- 例:
-https://github.com/user-attachments/assets/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
--->
-
-> 動画は別 Issue で追加予定です。
+https://github.com/Hiroyuki-12/RecipeManager/releases/download/v1.0.0/readme_demo.mp4
 
 ## 機能一覧
 


### PR DESCRIPTION
## Summary
- GitHub Releases (v1.0.0) に `readme_demo.mp4` をアップロード
- README のデモセクションの TODO コメントを削除し、動画URLを埋め込み
- `*.mp4` / `*.mov` を `.gitignore` に追加（動画はリポジトリに含めない運用）

## Test plan
- [ ] GitHub の README ページでデモセクションに動画プレイヤーが表示されることを確認

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)